### PR TITLE
Support Mongoose 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function(options) {
 		if (err.name !== 'MongoError') return null;
 		if (err.code !== 11000 && err.code !== 11001) return null;
 
-		var matches = /index:\s.*\.\$(.*)_1\sdup key:\s\{\s:\s"(.*)"\s\}/.exec(err.message);
+		var matches = /index:\s.*?\.?\$?(.*)_\d\sdup\s+key:\s*{\s*:\s*"(.*)"\s*}/.exec(err.message);
 
 		var result = {};
 		result[matches[1]] = {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
 	},
 	"main": "index.js",
 	"scripts": {
-		"test": "mocha test"
+		"test": "mocha test --exit"
 	},
 	"devDependencies": {
-		"mongoose": "^4.2.8",
+		"mongoose": "^5.4.20",
 		"i18n": "^0.5.0",
 		"express": "^4.13.3",
+		"mocha": "^6.0.2",
 		"should": "^7.1.1",
 		"supertest": "1.1.0"
 	}


### PR DESCRIPTION
The 'duplicate key' error message format changed slightly from 4 to 5.
The updated regex is more flexible, and should be backwards compatible.

Also adds the mocha test runner to devDependencies.

Tests are passing with Mongoose 5 👍 